### PR TITLE
Add sync between modbus TCP and RTU

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## [Unreleased]
+## [0.2.0] - 2022-02-20
+### Added
+- Modbus data between RTU and TCP can be synchronized continously. Access to
+  client is secured by thread lock ressource.
 
+### Changed
+- Reduce modbus logging output of get and set functions from `INFO` to `DEBUG`
+- Returned dict of `read_all_registers` clusters registers by type instead of
+  register names
+- Tuple of failed and successfully updated registers dict is returned on
+  register write functions instead of dictionary of failed registers only
+- Setting and getting register data is done in try-catch block to avoid errors
+  on unavailable registers or invalid response data
+- Log client register data as JSON instead of dict to improve later logging
+  data usage
+- Default logging level of `ModbusBridge` increased from `DEBUG` to `WARNING`
+
+### Fixed
+- Update host and client unit on setting new connections settings
+- Set logging level `INFO` not `DEBUG` if desired logger level is `info`
+- Return dictionary of read content in `read_all_registers`
+
+## Released
 ## [0.1.0] - 2022-02-19
 ### Added
 - This changelog file
@@ -31,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/0.1.0...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/0.2.0...develop
 
-
+[0.2.0]: https://github.com/brainelectronics/micropython-modules/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/micropython-modules/tree/0.1.0

--- a/generic_helper.py
+++ b/generic_helper.py
@@ -58,7 +58,7 @@ class GenericHelper(object):
         if level.lower() == 'debug':
             logger.setLevel(level=logging.DEBUG)
         elif level.lower() == 'info':
-            logger.setLevel(level=logging.DEBUG)
+            logger.setLevel(level=logging.INFO)
         elif level.lower() == 'warning':
             logger.setLevel(level=logging.WARNING)
         elif level.lower() == 'error':

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -486,7 +486,7 @@ class ModbusBridge(object):
             result = True
 
         if result is False:
-            self.logger.warning('No valid local IP found, using default')
+            self.logger.info('No valid local IP found, using default')
 
         return local_ip
 
@@ -639,18 +639,12 @@ class ModbusBridge(object):
                 # check time for data synchronisation
                 if time.time() > (last_update + interval):
                     last_update = time.time()
-                    last_update_ticks = time.ticks_ms()
 
                     # update data of client with latest changed host data
                     self._update_client_data()
 
                     # update data on host with latest data of client
                     self._update_host_data()
-
-                    time_diff = time.ticks_diff(time.ticks_ms(),
-                                                last_update_ticks)
-                    self.logger.debug('Complete data sync took: {}'.
-                                      format(time_diff))
                     # requires approx. 3000-5500ms
             except KeyboardInterrupt:
                 break
@@ -722,7 +716,8 @@ class ModbusBridge(object):
                             timestamp=data['time']
                         )
                     except Exception as e:
-                        self.logger.warning('Catched: {}'.format(e))
+                        self.logger.info('Failed to remove {}, catched: {}'.
+                                         format(reg, e))
 
             time_diff = time.ticks_diff(time.ticks_ms(),
                                         last_update_ticks)
@@ -747,19 +742,10 @@ class ModbusBridge(object):
 
         # lock client ressource
         self._client_usage_lock.acquire()
-        ressource_acquire_ticks = time.ticks_ms()
-        self.logger.debug('READ: Acquired ressource at {}ms'.
-                          format(ressource_acquire_ticks))
 
         # idle until ressource is locked
         while not self._client_usage_lock.locked():
             machine.idle()
-
-        ressource_granted_ticks = time.ticks_ms()
-        time_diff = time.ticks_diff(ressource_granted_ticks,
-                                    ressource_acquire_ticks)
-        self.logger.debug('READ: Granted ressource after {}ms'.
-                          format(time_diff))
 
         # Coils (setter+getter) [0, 1]
         self.logger.debug('Coils:')
@@ -804,10 +790,6 @@ class ModbusBridge(object):
 
         # release ressource
         self._client_usage_lock.release()
-        time_diff = time.ticks_diff(time.ticks_ms(),
-                                    ressource_granted_ticks)
-        self.logger.debug('READ: Release ressource after (locked for) {}ms'.
-                          format(time_diff))
 
         self.logger.debug('Complete read content: {}'.format(read_content))
 
@@ -831,19 +813,10 @@ class ModbusBridge(object):
 
         # lock client ressource
         self._client_usage_lock.acquire()
-        ressource_acquire_ticks = time.ticks_ms()
-        self.logger.debug('WRITE: Acquired ressource at {}ms'.
-                          format(ressource_acquire_ticks))
 
         # idle until ressource is locked
         while not self._client_usage_lock.locked():
             machine.idle()
-
-        ressource_granted_ticks = time.ticks_ms()
-        time_diff = time.ticks_diff(ressource_granted_ticks,
-                                    ressource_acquire_ticks)
-        self.logger.debug('WRITE: Granted ressource after {}ms'.
-                          format(time_diff))
 
         # Coils (setter+getter) [0, 1]
         self.logger.debug('Coils:')
@@ -887,10 +860,6 @@ class ModbusBridge(object):
 
         # release ressource
         self._client_usage_lock.release()
-        time_diff = time.ticks_diff(time.ticks_ms(),
-                                    ressource_granted_ticks)
-        self.logger.debug('WRITE: Release ressource after (locked for) {}ms'.
-                          format(time_diff))
 
         if any(reg for reg in failed_registers.values()):
             self.logger.info('Failed register updates: {}'.
@@ -940,8 +909,8 @@ class ModbusBridge(object):
                 self.logger.debug('\t{}\t{}'.format(register_address,
                                                     coil_status))
             except Exception as e:
-                self.logger.warning('Getting COIL {} failed, catched: {}'.
-                                    format(register_address, e))
+                self.logger.info('Getting COIL {} failed, catched: {}'.
+                                 format(register_address, e))
 
         return register_content
 
@@ -981,8 +950,8 @@ class ModbusBridge(object):
                     output_address=register_address,
                     output_value=register_value)
             except Exception as e:
-                self.logger.warning('Setting COIL {} failed, catched: {}'.
-                                    format(register_address, e))
+                self.logger.info('Setting COIL {} failed, catched: {}'.
+                                 format(register_address, e))
 
             self.logger.debug('Result of setting COIL {} to {}: {}'.
                               format(register_address,
@@ -1040,8 +1009,8 @@ class ModbusBridge(object):
                 self.logger.debug('\t{}\t{}'.format(register_address,
                                                     register_value))
             except Exception as e:
-                self.logger.warning('Getting HREG {} failed, catched: {}'.
-                                    format(register_address, e))
+                self.logger.info('Getting HREG {} failed, catched: {}'.
+                                 format(register_address, e))
 
         return register_content
 
@@ -1077,8 +1046,8 @@ class ModbusBridge(object):
                     register_value=register_value,
                     signed=signed)
             except Exception as e:
-                self.logger.warning('Setting HREG {} failed, catched: {}'.
-                                    format(register_address, e))
+                self.logger.info('Setting HREG {} failed, catched: {}'.
+                                 format(register_address, e))
 
             self.logger.debug('Result of setting HREGS {} to {}: {}'.
                               format(register_address,
@@ -1135,8 +1104,8 @@ class ModbusBridge(object):
                 self.logger.debug('\t{}\t{}'.format(register_address,
                                                     input_status))
             except Exception as e:
-                self.logger.warning('Setting HREG {} failed, catched: {}'.
-                                    format(register_address, e))
+                self.logger.info('Setting HREG {} failed, catched: {}'.
+                                 format(register_address, e))
 
         return register_content
 
@@ -1184,7 +1153,7 @@ class ModbusBridge(object):
                 self.logger.debug('\t{}\t{}'.format(register_address,
                                                     register_value))
             except Exception as e:
-                self.logger.warning('Getting IREG {} failed, catched: {}'.
-                                    format(register_address, e))
+                self.logger.info('Getting IREG {} failed, catched: {}'.
+                                 format(register_address, e))
 
         return register_content

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -618,7 +618,7 @@ class ModbusBridge(object):
             except KeyboardInterrupt:
                 break
 
-        print('Finished collecting client data')
+        self.logger.debug('Finished collecting client data')
 
     def _provision_host_data(self, interval: int, lock: int) -> None:
         """
@@ -655,7 +655,7 @@ class ModbusBridge(object):
             except KeyboardInterrupt:
                 break
 
-        print('Finished provisioning host data')
+        self.logger.debug('Finished provisioning host data')
 
     def _update_host_data(self) -> None:
         """Update host Modbus data with latest data received from client"""

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -818,26 +818,30 @@ class ModbusBridge(object):
             register_address = val['register']
             count = val['len']
 
-            coil_status = self.host.read_coils(
-                slave_addr=slave_addr,
-                starting_addr=register_address,
-                coil_qty=count)
+            try:
+                coil_status = self.host.read_coils(
+                    slave_addr=slave_addr,
+                    starting_addr=register_address,
+                    coil_qty=count)
 
-            if len(coil_status) == 1:
-                # only a single value
-                register_content[key] = {
-                    'register': register_address,
-                    'val': coil_status[0]
-                }
-            else:
-                # convert the tuple to list to be JSON conform
-                register_content[key] = {
-                    'register': register_address,
-                    'val': list(coil_status)
-                }
+                if len(coil_status) == 1:
+                    # only a single value
+                    register_content[key] = {
+                        'register': register_address,
+                        'val': coil_status[0]
+                    }
+                else:
+                    # convert the tuple to list to be JSON conform
+                    register_content[key] = {
+                        'register': register_address,
+                        'val': list(coil_status)
+                    }
 
-            self.logger.debug('\t{}\t{}'.format(register_address,
-                                                coil_status))
+                self.logger.debug('\t{}\t{}'.format(register_address,
+                                                    coil_status))
+            except Exception as e:
+                self.logger.warning('Getting COIL {} failed, catched: {}'.
+                                    format(register_address, e))
 
         return register_content
 
@@ -863,6 +867,7 @@ class ModbusBridge(object):
 
             register_address = key
             register_value = val['val']
+            operation_status = False
 
             # @see lib/uModbus/functions.write_single_coil
             if register_value is True:
@@ -870,10 +875,14 @@ class ModbusBridge(object):
             else:
                 register_value = 0x0000
 
-            operation_status = self.host.write_single_coil(
-                slave_addr=slave_addr,
-                output_address=register_address,
-                output_value=register_value)
+            try:
+                operation_status = self.host.write_single_coil(
+                    slave_addr=slave_addr,
+                    output_address=register_address,
+                    output_value=register_value)
+            except Exception as e:
+                self.logger.warning('Setting COIL {} failed, catched: {}'.
+                                    format(register_address, e))
 
             self.logger.debug('Result of setting COIL {} to {}: {}'.
                               format(register_address,
@@ -908,27 +917,31 @@ class ModbusBridge(object):
             register_address = val['register']
             count = val['len']
 
-            register_value = self.host.read_holding_registers(
-                slave_addr=slave_addr,
-                starting_addr=register_address,
-                register_qty=count,
-                signed=signed)
+            try:
+                register_value = self.host.read_holding_registers(
+                    slave_addr=slave_addr,
+                    starting_addr=register_address,
+                    register_qty=count,
+                    signed=signed)
 
-            if len(register_value) == 1:
-                # only a single value
-                register_content[key] = {
-                    'register': register_address,
-                    'val': register_value[0]
-                }
-            else:
-                # convert the tuple to list to be JSON conform
-                register_content[key] = {
-                    'register': register_address,
-                    'val': list(register_value)
-                }
+                if len(register_value) == 1:
+                    # only a single value
+                    register_content[key] = {
+                        'register': register_address,
+                        'val': register_value[0]
+                    }
+                else:
+                    # convert the tuple to list to be JSON conform
+                    register_content[key] = {
+                        'register': register_address,
+                        'val': list(register_value)
+                    }
 
-            self.logger.debug('\t{}\t{}'.format(register_address,
-                                                register_value))
+                self.logger.debug('\t{}\t{}'.format(register_address,
+                                                    register_value))
+            except Exception as e:
+                self.logger.warning('Getting HREG {} failed, catched: {}'.
+                                    format(register_address, e))
 
         return register_content
 
@@ -955,12 +968,17 @@ class ModbusBridge(object):
 
             register_address = key
             register_value = val['val']
+            operation_status = False
 
-            operation_status = self.host.write_single_register(
-                slave_addr=slave_addr,
-                register_address=register_address,
-                register_value=register_value,
-                signed=signed)
+            try:
+                operation_status = self.host.write_single_register(
+                    slave_addr=slave_addr,
+                    register_address=register_address,
+                    register_value=register_value,
+                    signed=signed)
+            except Exception as e:
+                self.logger.warning('Setting HREG {} failed, catched: {}'.
+                                    format(register_address, e))
 
             self.logger.debug('Result of setting HREGS {} to {}: {}'.
                               format(register_address,
@@ -995,26 +1013,30 @@ class ModbusBridge(object):
             register_address = val['register']
             count = val['len']
 
-            input_status = self.host.read_discrete_inputs(
-                slave_addr=slave_addr,
-                starting_addr=register_address,
-                input_qty=count)
+            try:
+                input_status = self.host.read_discrete_inputs(
+                    slave_addr=slave_addr,
+                    starting_addr=register_address,
+                    input_qty=count)
 
-            if len(input_status) == 1:
-                # only a single value
-                register_content[key] = {
-                    'register': register_address,
-                    'val': input_status[0]
-                }
-            else:
-                # convert the tuple to list to be JSON conform
-                register_content[key] = {
-                    'register': register_address,
-                    'val': list(input_status)
-                }
+                if len(input_status) == 1:
+                    # only a single value
+                    register_content[key] = {
+                        'register': register_address,
+                        'val': input_status[0]
+                    }
+                else:
+                    # convert the tuple to list to be JSON conform
+                    register_content[key] = {
+                        'register': register_address,
+                        'val': list(input_status)
+                    }
 
-            self.logger.debug('\t{}\t{}'.format(register_address,
-                                                input_status))
+                self.logger.debug('\t{}\t{}'.format(register_address,
+                                                    input_status))
+            except Exception as e:
+                self.logger.warning('Setting HREG {} failed, catched: {}'.
+                                    format(register_address, e))
 
         return register_content
 
@@ -1039,26 +1061,30 @@ class ModbusBridge(object):
             register_address = val['register']
             count = val['len']
 
-            register_value = self.host.read_input_registers(
-                slave_addr=slave_addr,
-                starting_addr=register_address,
-                register_qty=count,
-                signed=signed)
+            try:
+                register_value = self.host.read_input_registers(
+                    slave_addr=slave_addr,
+                    starting_addr=register_address,
+                    register_qty=count,
+                    signed=signed)
 
-            if len(register_value) == 1:
-                # only a single value
-                register_content[key] = {
-                    'register': register_address,
-                    'val': register_value[0]
-                }
-            else:
-                # convert the tuple to list to be JSON conform
-                register_content[key] = {
-                    'register': register_address,
-                    'val': list(register_value)
-                }
+                if len(register_value) == 1:
+                    # only a single value
+                    register_content[key] = {
+                        'register': register_address,
+                        'val': register_value[0]
+                    }
+                else:
+                    # convert the tuple to list to be JSON conform
+                    register_content[key] = {
+                        'register': register_address,
+                        'val': list(register_value)
+                    }
 
-            self.logger.debug('\t{}\t{}'.format(register_address,
-                                                register_value))
+                self.logger.debug('\t{}\t{}'.format(register_address,
+                                                    register_value))
+            except Exception as e:
+                self.logger.warning('Getting IREG {} failed, catched: {}'.
+                                    format(register_address, e))
 
         return register_content

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -134,6 +134,12 @@ class ModbusBridge(object):
         if val:
             self._connection_settings_host = val
 
+            if val.get('unit', ''):
+                unit = val['unit']
+                self.logger.debug('Update host connection unit to: {}'.
+                                  format(unit))
+                self.host_unit = unit
+
     @property
     def connection_settings_client(self) -> dict:
         """
@@ -154,6 +160,12 @@ class ModbusBridge(object):
         """
         if val:
             self._connection_settings_client = val
+
+            if val.get('unit', ''):
+                unit = val['unit']
+                self.logger.debug('Update client connection unit to: {}'.
+                                  format(unit))
+                self.client_unit = unit
 
     @property
     def client(self) -> Union[None, None]:
@@ -216,7 +228,8 @@ class ModbusBridge(object):
         if isinstance(val, int):
             self._client_unit = val
         else:
-            raise ModbusBridgeError('Client unit shall be int')
+            raise ModbusBridgeError('Client unit shall be int, not {}'.
+                                    format(type(val)))
 
     @property
     def host_unit(self) -> int:
@@ -239,7 +252,8 @@ class ModbusBridge(object):
         if isinstance(val, int):
             self._host_unit = val
         else:
-            raise ModbusBridgeError('Host unit shall be int')
+            raise ModbusBridgeError('Host unit shall be int, not {}'.
+                                    format(type(val)))
 
     def _load_register_file(self) -> Dict[dict]:
         """

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -913,8 +913,8 @@ class ModbusBridge(object):
 
             operation_status = self.host.write_single_register(
                 slave_addr=slave_addr,
-                output_address=register_address,
-                output_value=register_value,
+                register_address=register_address,
+                register_value=register_value,
                 signed=signed)
 
             self.logger.debug('Result of setting HREGS {} to {}: {}'.

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -463,7 +463,7 @@ class ModbusBridge(object):
         modbus_registers = self.register_definitions
 
         # Coils (setter+getter) [0, 1]
-        self.logger.info('Coils:')
+        self.logger.debug('Coils:')
         if 'COILS' in modbus_registers:
             coil_register_content = self.read_coil_registers()
             self.logger.debug('coil_register_content: {}'.
@@ -471,37 +471,37 @@ class ModbusBridge(object):
 
             read_content.update(coil_register_content)
         else:
-            self.logger.info('No COILS defined, skipping')
+            self.logger.debug('No COILS defined, skipping')
 
         # Hregs (setter+getter) [0, 65535]
-        self.logger.info('Hregs:')
+        self.logger.debug('Hregs:')
         if 'HREGS' in modbus_registers:
             hreg_register_content = self.read_hregs_registers()
             self.logger.debug('hreg_register_content: {}'.
                               format(hreg_register_content))
             read_content.update(hreg_register_content)
         else:
-            self.logger.info('No HREGS defined, skipping')
+            self.logger.debug('No HREGS defined, skipping')
 
         # Ists (only getter) [0, 1]
-        self.logger.info('Ists:')
+        self.logger.debug('Ists:')
         if 'ISTS' in modbus_registers:
             input_status_content = self.read_ists_registers()
             self.logger.debug('input_status_content: {}'.
                               format(input_status_content))
             read_content.update(input_status_content)
         else:
-            self.logger.info('No ISTS defined, skipping')
+            self.logger.debug('No ISTS defined, skipping')
 
         # Iregs (only getter) [0, 65535]
-        self.logger.info('Iregs:')
+        self.logger.debug('Iregs:')
         if 'IREGS' in modbus_registers:
             ireg_register_content = self.read_iregs_registers()
             self.logger.debug('ireg_register_content: {}'.
                               format(ireg_register_content))
             read_content.update(ireg_register_content)
         else:
-            self.logger.info('No IREGS defined, skipping')
+            self.logger.debug('No IREGS defined, skipping')
 
         self.logger.debug('Complete read content: {}'.format(read_content))
 
@@ -513,30 +513,30 @@ class ModbusBridge(object):
         :type       modbus_registers:  dict
         """
         # Coils (setter+getter) [0, 1]
-        self.logger.info('Coils:')
+        self.logger.debug('Coils:')
         if 'COILS' in modbus_registers:
             self.write_coil_registers(
                 modbus_registers=modbus_registers['COILS']
             )
         else:
-            self.logger.info('No COILS defined, skipping')
+            self.logger.debug('No COILS defined, skipping')
 
         # Hregs (setter+getter) [0, 65535]
-        self.logger.info('Hregs:')
+        self.logger.debug('Hregs:')
         if 'HREGS' in modbus_registers:
             self.write_hregs_registers(
                 modbus_registers=modbus_registers['HREGS']
             )
         else:
-            self.logger.info('No HREGS defined, skipping')
+            self.logger.debug('No HREGS defined, skipping')
 
         # Ists (only getter) [0, 1]
         if 'ISTS' in modbus_registers:
-            self.logger.info('ISTS can only be read, skipping')
+            self.logger.debug('ISTS can only be read, skipping')
 
         # Iregs (only getter) [0, 65535]
         if 'IREGS' in modbus_registers:
-            self.logger.info('IREGS can only be read, skipping')
+            self.logger.debug('IREGS can only be read, skipping')
 
     def read_coil_registers(self) -> dict:
         """
@@ -576,7 +576,8 @@ class ModbusBridge(object):
                     'val': list(coil_status)
                 }
 
-            self.logger.info('\t{}\t{}'.format(register_address, coil_status))
+            self.logger.debug('\t{}\t{}'.format(register_address,
+                                                coil_status))
 
         return register_content
 
@@ -654,8 +655,8 @@ class ModbusBridge(object):
                     'val': list(register_value)
                 }
 
-            self.logger.info('\t{}\t{}'.format(register_address,
-                                               register_value))
+            self.logger.debug('\t{}\t{}'.format(register_address,
+                                                register_value))
 
         return register_content
 
@@ -728,8 +729,8 @@ class ModbusBridge(object):
                     'val': list(input_status)
                 }
 
-            self.logger.info('\t{}\t{}'.format(register_address,
-                                               input_status))
+            self.logger.debug('\t{}\t{}'.format(register_address,
+                                                input_status))
 
         return register_content
 
@@ -773,7 +774,7 @@ class ModbusBridge(object):
                     'val': list(register_value)
                 }
 
-            self.logger.info('\t{}\t{}'.format(register_address,
-                                               register_value))
+            self.logger.debug('\t{}\t{}'.format(register_address,
+                                                register_value))
 
         return register_content

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -638,7 +638,7 @@ class ModbusBridge(object):
             self.logger.debug('coil_register_content: {}'.
                               format(coil_register_content))
 
-            read_content.update(coil_register_content)
+            read_content['COILS'] = coil_register_content
         else:
             self.logger.debug('No COILS defined, skipping')
 
@@ -648,7 +648,7 @@ class ModbusBridge(object):
             hreg_register_content = self.read_hregs_registers()
             self.logger.debug('hreg_register_content: {}'.
                               format(hreg_register_content))
-            read_content.update(hreg_register_content)
+            read_content['HREGS'] = hreg_register_content
         else:
             self.logger.debug('No HREGS defined, skipping')
 
@@ -658,7 +658,7 @@ class ModbusBridge(object):
             input_status_content = self.read_ists_registers()
             self.logger.debug('input_status_content: {}'.
                               format(input_status_content))
-            read_content.update(input_status_content)
+            read_content['ISTS'] = input_status_content
         else:
             self.logger.debug('No ISTS defined, skipping')
 
@@ -668,7 +668,7 @@ class ModbusBridge(object):
             ireg_register_content = self.read_iregs_registers()
             self.logger.debug('ireg_register_content: {}'.
                               format(ireg_register_content))
-            read_content.update(ireg_register_content)
+            read_content['IREGS'] = ireg_register_content
         else:
             self.logger.debug('No IREGS defined, skipping')
 

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -9,6 +9,7 @@ Create bridge between RTU and TCP modbus requests
 
 # system packages
 import gc
+import json
 import network
 import _thread
 import time
@@ -340,7 +341,8 @@ class ModbusBridge(object):
         self.logger.debug('Free memory: {}'.format(free))
 
         _client_data = self._client_data_msg.value()
-        self.logger.info('Latest client data: {}'.format(_client_data))
+        self.logger.info('Latest client data: {}'.
+                         format(json.dumps(_client_data)))
 
         # update data only if not empty
         if _client_data:

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -828,7 +828,7 @@ class ModbusBridge(object):
             self.logger.debug('\tkey: {}'.format(key))
             self.logger.debug('\t\tval: {}'.format(val))
 
-            register_address = val['register']
+            register_address = key
             register_value = val['val']
 
             # @see lib/uModbus/functions.write_single_coil
@@ -908,7 +908,7 @@ class ModbusBridge(object):
             self.logger.debug('\tkey: {}'.format(key))
             self.logger.debug('\t\tval: {}'.format(val))
 
-            register_address = val['register']
+            register_address = key
             register_value = val['val']
 
             operation_status = self.host.write_single_register(

--- a/modbus_bridge.py
+++ b/modbus_bridge.py
@@ -389,8 +389,8 @@ class ModbusBridge(object):
                 pins=pins,
                 # ctrl_pin=MODBUS_PIN_TX_EN
             )
-            self.logger.debug('Created RTU host to collect from {} at {} baud'.
-                              format(pins, baudrate))
+            self.logger.info('Created RTU host to collect from {} at {} baud'.
+                             format(pins, baudrate))
         elif _client_cfg.get('type', '').lower() == 'tcp':
             # act as host, get Modbus data via TCP from a client device
             # do not use 'get()' here, as there exists no valid fallback value
@@ -400,8 +400,8 @@ class ModbusBridge(object):
                 slave_ip=slave_ip,
                 slave_port=port
             )
-            self.logger.debug('Created TCP host to collect from {}:{}'.
-                              format(slave_ip, port))
+            self.logger.info('Created TCP host to collect from {}:{}'.
+                             format(slave_ip, port))
 
         if _host_cfg.get('type', '').lower() == 'rtu':
             # act as client, provide Modbus data via RTU to a host device
@@ -419,8 +419,8 @@ class ModbusBridge(object):
                 pins=pins,
                 # ctrl_pin=MODBUS_PIN_TX_EN
             )
-            self.logger.debug('Created RTU client to serve on {} at {} baud'.
-                              format(bus_address, baudrate))
+            self.logger.info('Created RTU client to serve on {} at {} baud'.
+                             format(bus_address, baudrate))
         elif _host_cfg.get('type', '').lower() == 'tcp':
             # act as client, provide Modbus data via TCP to a host device
             _client = ModbusTCP()
@@ -449,8 +449,8 @@ class ModbusBridge(object):
                 _client.bind(local_ip=local_ip, local_port=port)
                 self.logger.debug('Modbus TCP client binding done')
 
-            self.logger.debug('Created TCP client to serve on {}:{}'.
-                              format(local_ip, port))
+            self.logger.info('Created TCP client to serve on {}:{}'.
+                             format(local_ip, port))
 
             _client.setup_registers(registers=self.register_definitions,
                                     use_default_vals=True)
@@ -518,6 +518,8 @@ class ModbusBridge(object):
             self.logger.debug('No IREGS defined, skipping')
 
         self.logger.debug('Complete read content: {}'.format(read_content))
+
+        return read_content
 
     def write_all_registers(self, modbus_registers: dict) -> None:
         """


### PR DESCRIPTION
### Added
- Modbus data between RTU and TCP can be synchronized continously. Access to client is secured by thread lock ressource.

### Changed
- Reduce modbus logging output of get and set functions from `INFO` to `DEBUG`
- Returned dict of `read_all_registers` clusters registers by type instead of register names
- Tuple of failed and successfully updated registers dict is returned on register write functions instead of dictionary of failed registers only
- Setting and getting register data is done in try-catch block to avoid errors on unavailable registers or invalid response data
- Log client register data as JSON instead of dict to improve later logging data usage
- Default logging level of `ModbusBridge` increased from `DEBUG` to `WARNING`

### Fixed
- Update host and client unit on setting new connections settings
- Set logging level `INFO` not `DEBUG` if desired logger level is `info`
- Return dictionary of read content in `read_all_registers`