### PR TITLE
Bugfix/invalid import calls

### DIFF
--- a/be_helpers/__init__.py
+++ b/be_helpers/__init__.py
@@ -1,13 +1,4 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-from .generic_helper import GenericHelper
-from .led_helper import Led, Neopixel
-from .modbus_bridge import ModbusBridge, ModbusBridgeError
-from .path_helper import PathHelper
-from .time_helper import TimeHelper
-from .typing import *
-from .update_helper import UpdateHelper
-from .wifi_helper import WifiHelper
-
 from .version import __version__

--- a/be_helpers/generic_helper.py
+++ b/be_helpers/generic_helper.py
@@ -13,8 +13,9 @@ import ulogging as logging
 import os
 import random
 
-# not natively supported on micropython, see typing.py
-from typing import Optional, Union
+# custom packages
+# typing not natively supported on MicroPython
+from .typing import Optional, Union
 
 
 class GenericHelper(object):

--- a/be_helpers/led_helper.py
+++ b/be_helpers/led_helper.py
@@ -12,8 +12,9 @@ import neopixel
 import _thread
 import time
 
-# not natively supported on micropython, see lib/typing.py
-from typing import Union
+# custom packages
+# typing not natively supported on MicroPython
+from .typing import Union
 
 
 class Led(object):

--- a/be_helpers/modbus_bridge.py
+++ b/be_helpers/modbus_bridge.py
@@ -16,22 +16,19 @@ import _thread
 import time
 
 # pip installed packages
-# import picoweb
-# https://github.com/pfalcon/picoweb/blob/b74428ebdde97ed1795338c13a3bdf05d71366a0/picoweb/
 from uModbus.serial import Serial as ModbusRTUMaster
 from uModbus.tcp import TCP as ModbusTCPMaster
 # https://github.com/brainelectronics/micropython-modbus/
-from primitives.message import Message
-# https://github.com/peterhinch/micropython-async/blob/a87bda1b716090da27fd288cc8b19b20525ea20c/v3/primitives/
 
 # custom packages
-from helpers.generic_helper import GenericHelper
-from helpers.path_helper import PathHelper
+from .generic_helper import GenericHelper
+from .message import Message
+from .path_helper import PathHelper
+# typing not natively supported on MicroPython
+from .typing import Dict, Tuple, Union
+
 from modbus import ModbusRTU
 from modbus import ModbusTCP
-
-# not natively supported on micropython, see lib/typing.py
-from typing import Dict, Tuple, Union
 
 
 class ModbusBridgeError(Exception):

--- a/be_helpers/version.py
+++ b/be_helpers/version.py
@@ -1,2 +1,2 @@
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 __author__ = 'brainelectronics'

--- a/be_helpers/wifi_helper.py
+++ b/be_helpers/wifi_helper.py
@@ -14,10 +14,10 @@ import network
 import time
 from collections import namedtuple
 
+# custom packages
 from .time_helper import TimeHelper
-
-# not natively supported on micropython, see lib/typing.py
-from typing import (List, NamedTuple, Union)
+# typing not natively supported on MicroPython
+from .typing import List, NamedTuple, Union
 
 
 class WifiHelper(object):

--- a/changelog.md
+++ b/changelog.md
@@ -13,10 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Released
+## [1.1.1] - 2022-02-25
+### Fixed
+- Adopted import paths of `typing` module in all modules from
+ `from typing import *` to `from .typing import *`
+- Do not import any modules in [`__init__.py`](be_helpers/__init__.py) other
+  than [`version.py`](be_helpers/version.py) to avoid issues and gain speed
+
 ## [1.1.0] - 2022-02-25
 ### Added
-- [`message.py`](be_helpers/message.py) and [`queue.py`](/queue.py) taken from
-  [peterhinch's micropython async repo][ref-peterhinch-async]
+- [`message.py`](be_helpers/message.py) and [`queue.py`](be_helpers/queue.py)
+  taken from [peterhinch's micropython async repo][ref-peterhinch-async]
 
 ## [1.0.0] - 2022-02-24
 ### Added
@@ -75,8 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.1.0...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.1.1...develop
 
+[1.1.1]: https://github.com/brainelectronics/micropython-modules/tree/1.1.1
 [1.1.0]: https://github.com/brainelectronics/micropython-modules/tree/1.1.0
 [1.0.0]: https://github.com/brainelectronics/micropython-modules/tree/1.0.0
 [0.2.0]: https://github.com/brainelectronics/micropython-modules/tree/0.2.0


### PR DESCRIPTION
### Fixed
- Adopted import paths of `typing` module in all modules from `from typing import *` to `from .typing import *`
- Do not import any modules in [`__init__.py`](be_helpers/__init__.py) other than [`version.py`](be_helpers/version.py) to avoid issues and gain speed