### PR TITLE
Update import paths for umodbus lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,11 +273,18 @@ pixel.color = 'DarlingColor'
 This requires [brainelectronics MicroPython Modbus][ref-be-upy-modbus]. Forked
 and extended from [SFERALABS Exo Sense Py][ref-sferalabs-exo-sense].
 
+Connect the board to a network and install the package like this
+
+```python
+import upip
+upip.install('micropython-modbus')
+```
+
 ```python
 import time
 import machine
 
-from be_helpers import ModbusBridge
+from be_helpers.modbus_bridge import ModbusBridge
 
 register_file = 'registers/modbusRegisters-MyEVSE.json'
 rtu_pins = (25, 26)     # (TX, RX)

--- a/be_helpers/modbus_bridge.py
+++ b/be_helpers/modbus_bridge.py
@@ -579,8 +579,8 @@ class ModbusBridge(object):
             self.logger.info('Created TCP client to serve on {}:{}'.
                              format(local_ip, port))
 
-            _client.setup_registers(registers=self.register_definitions,
-                                    use_default_vals=True)
+        _client.setup_registers(registers=self.register_definitions,
+                                use_default_vals=True)
 
         self.host = _host
         self.client = _client

--- a/be_helpers/modbus_bridge.py
+++ b/be_helpers/modbus_bridge.py
@@ -15,20 +15,21 @@ import network
 import _thread
 import time
 
-# pip installed packages
-from uModbus.serial import Serial as ModbusRTUMaster
-from uModbus.tcp import TCP as ModbusTCPMaster
-# https://github.com/brainelectronics/micropython-modbus/
-
 # custom packages
+# pip installed packages
+# https://github.com/brainelectronics/micropython-modules
 from .generic_helper import GenericHelper
 from .message import Message
 from .path_helper import PathHelper
 # typing not natively supported on MicroPython
 from .typing import Dict, Tuple, Union
 
-from modbus import ModbusRTU
-from modbus import ModbusTCP
+# https://github.com/brainelectronics/micropython-modbus/
+# upip.install('micropython-modbus')
+from umodbus.serial import Serial as ModbusRTUMaster
+from umodbus.tcp import TCP as ModbusTCPMaster
+from umodbus.modbus import ModbusRTU
+from umodbus.modbus import ModbusTCP
 
 
 class ModbusBridgeError(Exception):

--- a/be_helpers/version.py
+++ b/be_helpers/version.py
@@ -1,2 +1,2 @@
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 __author__ = 'brainelectronics'

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Released
+## [1.1.2] - 2022-02-26
+### Fixed
+- Adopted import path of `modbus_bridge` in Modbus Bridge example in
+  [`README`](README.md).
+- Adopted import paths of `umodbus` files in
+  [`modbus_bridge.py`](be_helpers/modbus_bridge.py)
+- Provide installation instructions for `micropython-modbus` library in
+  [`README`](README.md)
+- Call `setup_registers` for either TCP or RTU client, not only in TCP client
+  mode in [`modbus_bridge.py`](be_helpers/modbus_bridge.py)
+
 ## [1.1.1] - 2022-02-25
 ### Fixed
 - Adopted import paths of `typing` module in all modules from
@@ -82,8 +93,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.1.1...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.1.2...develop
 
+[1.1.2]: https://github.com/brainelectronics/micropython-modules/tree/1.1.2
 [1.1.1]: https://github.com/brainelectronics/micropython-modules/tree/1.1.1
 [1.1.0]: https://github.com/brainelectronics/micropython-modules/tree/1.1.0
 [1.0.0]: https://github.com/brainelectronics/micropython-modules/tree/1.0.0


### PR DESCRIPTION
### Fixed
- Adopted import path of `modbus_bridge` in Modbus Bridge example in [`README`](README.md).
- Adopted import paths of `umodbus` files in [`modbus_bridge.py`](be_helpers/modbus_bridge.py)
- Provide installation instructions for `micropython-modbus` library in [`README`](README.md)
- Call `setup_registers` for either TCP or RTU client, not only in TCP client mode in [`modbus_bridge.py`](be_helpers/modbus_bridge.py)
