### PR TITLE
Add system info functions

### DIFF
--- a/be_helpers/generic_helper.py
+++ b/be_helpers/generic_helper.py
@@ -12,6 +12,7 @@ import json
 import ulogging as logging
 import os
 import random
+import time
 
 # custom packages
 # typing not natively supported on MicroPython
@@ -159,6 +160,56 @@ class GenericHelper(object):
                     format(memory_stats['total'] / 1024,
                            memory_stats['free'] / 1024,
                            memory_stats['percentage']))
+
+    @staticmethod
+    def get_system_infos_raw() -> dict:
+        """
+        Get the raw system infos.
+
+        :returns:   The raw system infos.
+        :rtype:     dict
+        """
+        sys_info = dict()
+        memory_info = GenericHelper.get_free_memory()
+
+        sys_info['df'] = GenericHelper.df(path='/', unit='kB')
+        sys_info['free_ram'] = memory_info['free']
+        sys_info['total_ram'] = memory_info['total']
+        sys_info['percentage_ram'] = memory_info['percentage']
+        sys_info['frequency'] = machine.freq()
+        sys_info['uptime'] = time.ticks_ms()
+
+        return sys_info
+
+    @staticmethod
+    def get_system_infos_human() -> dict:
+        """
+        Get the human formatted system infos
+
+        :returns:   The human formatted system infos.
+        :rtype:     dict
+        """
+        sys_info = dict()
+        memory_info = GenericHelper.get_free_memory()
+
+        # (year, month, mday, hour, minute, second, weekday, yearday)
+        # (0,    1,     2,    3,    4,      5,      6,       7)
+        seconds = int(time.ticks_ms() / 1000)
+        uptime = time.gmtime(seconds)
+        days = "{days:01d}".format(days=int(seconds / 86400))
+
+        sys_info['df'] = GenericHelper.df(path='/', unit='kB')
+        sys_info['free_ram'] = "{} kB".format(memory_info['free'] / 1000.0)
+        sys_info['total_ram'] = "{} kB".format(memory_info['total'] / 1000.0)
+        sys_info['percentage_ram'] = memory_info['percentage']
+        sys_info['frequency'] = "{} MHz".format(int(machine.freq() / 1000000))
+        sys_info['uptime'] = "{d} days, {hour:02d}:{min:02d}:{sec:02d}".format(
+                                d=days,
+                                hour=uptime[3],
+                                min=uptime[4],
+                                sec=uptime[5])
+
+        return sys_info
 
     @staticmethod
     def str_to_dict(data: str) -> dict:

--- a/be_helpers/modbus_bridge.py
+++ b/be_helpers/modbus_bridge.py
@@ -335,10 +335,6 @@ class ModbusBridge(object):
 
     @property
     def client_data(self) -> Dict[dict]:
-        gc.collect()
-        free = gc.mem_free()
-        self.logger.debug('Free memory: {}'.format(free))
-
         _client_data = self._client_data_msg.value()
         self.logger.debug('Latest client data: {}'.
                           format(json.dumps(_client_data)))

--- a/be_helpers/version.py
+++ b/be_helpers/version.py
@@ -1,2 +1,3 @@
-__version__ = '1.1.2'
+__version_info__ = ('1', '2', '0')
+__version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/be_helpers/wifi_helper.py
+++ b/be_helpers/wifi_helper.py
@@ -8,11 +8,11 @@ Connect to specified network(s) or create an accesspoint
 """
 
 import ubinascii
+from collections import namedtuple
 import json
 import machine
 import network
 import time
-from collections import namedtuple
 
 # custom packages
 from .time_helper import TimeHelper

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Released
+## [1.2.0] - 2022-03-06
+### Added
+- [`version.py`](be_helpers/version.py) provides info as semver tuple with
+  `__version_info__`
+- Raw and human encoded system info data is provided by function
+  `get_system_infos_raw` and `get_system_infos_human` of
+  [`generic_helper.py`](be_helpers/generic_helper.py)
+
+### Changed
+- `gc.collect()` is no longer called on `client_data` property access of
+  [`modbus_bridge.py`](be_helpers/modbus_bridge.py)
+
+### Fixed
+- Adopted import paths of Generic helper, Led, Neopixel, Path helper, Time
+  helper and WiFi helper examples in [`README`](README.md).
+
 ## [1.1.2] - 2022-02-26
 ### Fixed
 - Adopted import path of `modbus_bridge` in Modbus Bridge example in
@@ -93,8 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.1.2...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.2.0...develop
 
+[1.2.0]: https://github.com/brainelectronics/micropython-modules/tree/1.2.0
 [1.1.2]: https://github.com/brainelectronics/micropython-modules/tree/1.1.2
 [1.1.1]: https://github.com/brainelectronics/micropython-modules/tree/1.1.1
 [1.1.0]: https://github.com/brainelectronics/micropython-modules/tree/1.1.0


### PR DESCRIPTION
### Added
- [`version.py`](be_helpers/version.py) provides info as semver tuple with `__version_info__`
- Raw and human encoded system info data is provided by function `get_system_infos_raw` and `get_system_infos_human` of [`generic_helper.py`](be_helpers/generic_helper.py)

### Changed
- `gc.collect()` is no longer called on `client_data` property access of [`modbus_bridge.py`](be_helpers/modbus_bridge.py)