### PR TITLE
Remove debug print of client data

### DIFF
--- a/be_helpers/modbus_bridge.py
+++ b/be_helpers/modbus_bridge.py
@@ -336,8 +336,6 @@ class ModbusBridge(object):
     @property
     def client_data(self) -> Dict[dict]:
         _client_data = self._client_data_msg.value()
-        self.logger.debug('Latest client data: {}'.
-                          format(json.dumps(_client_data)))
 
         # update data only if not empty
         if _client_data:

--- a/be_helpers/version.py
+++ b/be_helpers/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('1', '2', '1')
+__version_info__ = ('1', '2', '2')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Released
-## [1.2.0] - 2022-03-07
+## [1.2.2] - 2022-03-11
+### Changed
+- Client data is no logger logged with debug level on `client_data` property
+  access to reduce time before data return
+
+## [1.2.1] - 2022-03-07
 ### Fixed
 - Added missing `machine` import to
   [`generic_helper.py`](be_helpers/generic_helper.py)
@@ -114,8 +119,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.2.1...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.2.2...develop
 
+[1.2.2]: https://github.com/brainelectronics/micropython-modules/tree/1.2.2
 [1.2.1]: https://github.com/brainelectronics/micropython-modules/tree/1.2.1
 [1.2.0]: https://github.com/brainelectronics/micropython-modules/tree/1.2.0
 [1.1.2]: https://github.com/brainelectronics/micropython-modules/tree/1.1.2


### PR DESCRIPTION
Even if the logging level is not set to `debug` the data is still processed by `json.dumps` before not being printed to stream due to higher logging level threshold.

### Changed
- Client data is no logger logged with debug level on `client_data` property  access to reduce time before data return