### PR TITLE
Add function for UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ GenericHelper.df(path='/', unit='kb')
 GenericHelper.get_free_memory()
 # >>> {'percentage': '99.76%', 'total': 4098240, 'free': 4088400}
 
+# get UUID of default length, might be different on PyCOM, MicroPython, ...
+GenericHelper.get_uuid()
+# >>> b'308398d9eefc'
+# GenericHelper.get_uuid(length=18)
+# >>> b'308398d9eefc308398'
+
 # get detailed info (full == True) RAM informations
 GenericHelper.free(full=True)
 # >>> 'Total: 4006.1 kB, Free: 3992.56 kB (99.76%)'

--- a/be_helpers/generic_helper.py
+++ b/be_helpers/generic_helper.py
@@ -14,6 +14,7 @@ import machine
 import os
 import random
 import time
+import ubinascii
 
 # custom packages
 # typing not natively supported on MicroPython
@@ -85,6 +86,27 @@ class GenericHelper(object):
         :rtype:     int
         """
         return random.randint(lower, upper)
+
+    @staticmethod
+    def get_uuid(length: Optional[int] = None) -> bytes:
+        """
+        Get the UUID of the device.
+
+        :param      length:  The length of the UUID
+        :type       length:  int, optional
+
+        :returns:   The uuid.
+        :rtype:     bytes
+        """
+        uuid = ubinascii.hexlify(machine.unique_id())
+
+        if length:
+            uuid_len = len(uuid)
+            amount = length // uuid_len + (length % uuid_len > 0)
+
+            return (uuid * amount)[:length]
+        else:
+            return uuid
 
     @staticmethod
     def df(path: str = '//', unit: Optional[str] = None) -> Union[int, str]:

--- a/be_helpers/version.py
+++ b/be_helpers/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('1', '2', '3')
+__version_info__ = ('1', '3', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Released
+## [1.3.0] - 2022-04-16
+### Added
+- `get_uuid` can be used to get the unique ID of the device or with an optional
+  parameter `lenght` to return the UUID of desired length, see
+  [#11][ref-issue-11]
+
 ## [1.2.3] - 2022-03-20
 ### Fixed
 - WiFi station is no longer deactivated if no WiFi networks have been found.
@@ -125,8 +131,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.2.3...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.3.0...develop
 
+[1.3.0]: https://github.com/brainelectronics/micropython-modules/tree/1.3.0
 [1.2.3]: https://github.com/brainelectronics/micropython-modules/tree/1.2.3
 [1.2.2]: https://github.com/brainelectronics/micropython-modules/tree/1.2.2
 [1.2.1]: https://github.com/brainelectronics/micropython-modules/tree/1.2.1
@@ -138,6 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/brainelectronics/micropython-modules/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/micropython-modules/tree/0.1.0
 
+[ref-issue-11]: https://github.com/brainelectronics/micropython-modules/issues/11
 [ref-issue-9]: https://github.com/brainelectronics/micropython-modules/issues/9
 [ref-pypi]: https://pypi.org/
 [ref-pfalcon-picoweb-sdist-upip]: https://github.com/pfalcon/picoweb/blob/b74428ebdde97ed1795338c13a3bdf05d71366a0/sdist_upip.py


### PR DESCRIPTION
`get_uuid` can be used to get the unique ID of the device or with an optional parameter `lenght` to return the UUID of desired length, see #11 