### PR TITLE
Extend function for UUID

### DIFF
--- a/be_helpers/generic_helper.py
+++ b/be_helpers/generic_helper.py
@@ -100,11 +100,14 @@ class GenericHelper(object):
         """
         uuid = ubinascii.hexlify(machine.unique_id())
 
-        if length:
+        if length is not None:
             uuid_len = len(uuid)
-            amount = length // uuid_len + (length % uuid_len > 0)
+            amount = abs(length) // uuid_len + (abs(length) % uuid_len > 0)
 
-            return (uuid * amount)[:length]
+            if length < 0:
+                return (uuid * amount)[length:]
+            else:
+                return (uuid * amount)[:length]
         else:
             return uuid
 

--- a/be_helpers/version.py
+++ b/be_helpers/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('1', '3', '0')
+__version_info__ = ('1', '4', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Released
+## [1.4.0] - 2022-05-06
+### Changed
+- `get_uuid` can be used to get the first or last n characters of the unique
+  ID of the device, see additional comment in [#11][ref-issue-11]
+
 ## [1.3.0] - 2022-04-16
 ### Added
 - `get_uuid` can be used to get the unique ID of the device or with an optional
@@ -131,8 +136,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.3.0...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.4.0...develop
 
+[1.4.0]: https://github.com/brainelectronics/micropython-modules/tree/1.4.0
 [1.3.0]: https://github.com/brainelectronics/micropython-modules/tree/1.3.0
 [1.2.3]: https://github.com/brainelectronics/micropython-modules/tree/1.2.3
 [1.2.2]: https://github.com/brainelectronics/micropython-modules/tree/1.2.2


### PR DESCRIPTION
### Changed
- `get_uuid` can be used to get the first or last n characters of the unique ID of the device, see additional comment in [#11][ref-issue-11]
