### PR TITLE
Improve time helper and update micropython modbus imports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,14 @@ on:
       - develop
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -41,3 +41,16 @@ jobs:
         skip_existing: true
         verbose: true
         print_hash: true
+    - name: 'Create changelog based release'
+      uses: brainelectronics/changelog-based-release@v1
+      with:
+        # note you'll typically need to create a personal access token
+        # with permissions to create releases in the other repo
+        # or you set the "contents" permissions to "write" as in this example
+        changelog-path: changelog.md
+        tag-name-prefix: ''
+        tag-name-extension: ''
+        release-name-prefix: ''
+        release-name-extension: ''
+        draft-release: true
+        prerelease: false

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -6,14 +6,14 @@ name: Upload Python Package to test.pypi.org
 on: [pull_request]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   test-deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -51,3 +51,16 @@ jobs:
         skip_existing: true
         verbose: true
         print_hash: true
+    - name: 'Create changelog based prerelease'
+      uses: brainelectronics/changelog-based-release@v1
+      with:
+        # note you'll typically need to create a personal access token
+        # with permissions to create releases in the other repo
+        # or you set the "contents" permissions to "write" as in this example
+        changelog-path: changelog.md
+        tag-name-prefix: ''
+        tag-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
+        release-name-prefix: ''
+        release-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
+        draft-release: true
+        prerelease: true

--- a/be_helpers/led_helper.py
+++ b/be_helpers/led_helper.py
@@ -55,7 +55,7 @@ class Led(object):
         self.blink_delay = delay_ms
         self.blinking = True
 
-    def _blink(self, delay_ms: int, lock: lock) -> None:    # noqa
+    def _blink(self, delay_ms: int, lock: lock) -> None:    # noqa: F821
         """
         Internal blink thread content.
 

--- a/be_helpers/modbus_bridge.py
+++ b/be_helpers/modbus_bridge.py
@@ -26,9 +26,9 @@ from .typing import Dict, Tuple, Union
 # https://github.com/brainelectronics/micropython-modbus/
 # upip.install('micropython-modbus')
 from umodbus.serial import Serial as ModbusRTUMaster
+from umodbus.serial import ModbusRTU
 from umodbus.tcp import TCP as ModbusTCPMaster
-from umodbus.modbus import ModbusRTU
-from umodbus.modbus import ModbusTCP
+from umodbus.tcp import ModbusTCP
 
 
 class ModbusBridgeError(Exception):

--- a/be_helpers/time_helper.py
+++ b/be_helpers/time_helper.py
@@ -121,6 +121,18 @@ class TimeHelper(object):
         return self.rtc.datetime()[2]
 
     @property
+    def weekday(self) -> int:
+        """
+        Current weekday from RTC
+
+        :returns:   This weekday
+        :rtype:     int
+        """
+        # (y,    m,  d, wd, h, m,  s, subseconds)
+        # (2021, 7, 15, 5, 19, 12, 25, 1, 196)
+        return self.rtc.datetime()[3]
+
+    @property
     def hour(self) -> int:
         """
         Current hour from RTC

--- a/be_helpers/time_helper.py
+++ b/be_helpers/time_helper.py
@@ -38,6 +38,7 @@ class TimeHelper(object):
         tm = time.localtime()
         print("Local time before synchronization: {}".format(tm))
         # Local time before synchronization: (2000, 1, 1, 0, 9, 44, 5, 1)
+        #                                    (y, m, d, h, min, sec, wd, yd)
 
         # sync time with NTP server
         try:
@@ -58,8 +59,10 @@ class TimeHelper(object):
         # (year, m, day, h, min,sec, weekday, yearday)
         # (0,    1,  2,  3,  4,   5,       6, 7)
 
-        # year, month, day, weekday, hours, minutes, seconds, subsec
-        self.rtc.init((tm[0], tm[1], tm[2], tm[6], tm[3], tm[4], tm[5], 0))
+        #    year, month, day, hour, minute, second, subsec, tzinfo
+        self.rtc.init(
+            (tm[0], tm[1], tm[2], tm[3], tm[4], tm[5], 0, self.timezone)
+        )
 
     @property
     def timezone(self) -> int:
@@ -89,8 +92,8 @@ class TimeHelper(object):
         :returns:   This year
         :rtype:     int
         """
-        # (y,    m,  d,  h,  m,  s, subseconds)
-        # (self.2021, 7, 15, 19, 12, 25, 1, 196)
+        # (y,    m,  d, wd, h, m,  s, subseconds)
+        # (2021, 7, 15, 5, 19, 12, 25, 1, 196)
         return self.rtc.datetime()[0]
 
     @property
@@ -101,8 +104,8 @@ class TimeHelper(object):
         :returns:   This month
         :rtype:     int
         """
-        # (y,    m,  d,  h,  m,  s, subseconds)
-        # (2021, 7, 15, 19, 12, 25, 1, 196)
+        # (y,    m,  d, wd, h, m,  s, subseconds)
+        # (2021, 7, 15, 5, 19, 12, 25, 1, 196)
         return self.rtc.datetime()[1]
 
     @property
@@ -113,8 +116,8 @@ class TimeHelper(object):
         :returns:   This day
         :rtype:     int
         """
-        # (y,    m,  d,  h,  m,  s, subseconds)
-        # (2021, 7, 15, 19, 12, 25, 1, 196)
+        # (y,    m,  d, wd, h, m,  s, subseconds)
+        # (2021, 7, 15, 5, 19, 12, 25, 1, 196)
         return self.rtc.datetime()[2]
 
     @property
@@ -125,8 +128,8 @@ class TimeHelper(object):
         :returns:   This hour
         :rtype:     int
         """
-        # (y,    m,  d,  h,  m,  s, subseconds)
-        # (2021, 7, 15, 19, 12, 25, 1, 196)
+        # (y,    m,  d, wd, h, m,  s, subseconds)
+        # (2021, 7, 15, 5, 19, 12, 25, 1, 196)
         return self.rtc.datetime()[4]
 
     @property
@@ -137,8 +140,8 @@ class TimeHelper(object):
         :returns:   This minute
         :rtype:     int
         """
-        # (y,    m,  d,  h,  m,  s, subseconds)
-        # (2021, 7, 15, 19, 12, 25, 1, 196)
+        # (y,    m,  d, wd, h, m,  s, subseconds)
+        # (2021, 7, 15, 5, 19, 12, 25, 1, 196)
         return self.rtc.datetime()[5]
 
     @property
@@ -149,8 +152,8 @@ class TimeHelper(object):
         :returns:   This second
         :rtype:     int
         """
-        # (y,    m,  d,  h,  m,  s, subseconds)
-        # (2021, 7, 15, 19, 12, 25, 1, 196)
+        # (y,    m,  d, wd, h, m,  s, subseconds)
+        # (2021, 7, 15, 5, 19, 12, 25, 1, 196)
         return self.rtc.datetime()[6]
 
     @property

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Released
+## [1.6.0] - 2022-12-11
+### Added
+- Use [changelog-based-release action](https://github.com/brainelectronics/changelog-based-release) to create a draft release with every merge to develop
+- Use [changelog-based-release action](https://github.com/brainelectronics/changelog-based-release) to create a drafted prerelease release with every PR build
+
+### Changed
+- Apply changes for [micropython-modbus 2.0.0](https://github.com/brainelectronics/micropython-modbus/pull/33), see #16
+- Scope of contents permissions in release and test release workflow is now `write` to use auto release creation
+- Use `checkout@v3` instead of `checkout@v2` in all workflows
+- Line breaks are no longer used in this changelog for enumerations
+- Issues are referenced as `#123` instead of `[#123][ref-issue-123]` to avoid explicit references at the bottom or some other location in the file
+
+### Fixed
+- Use more specific `noqa` in [`led_helper.py`](be_helpers/led_helper.py)
+
 ## [1.5.0] - 2022-11-03
 ### Added
 - Deploy to [Test Python Package Index](https://test.pypi.org/) on every PR
@@ -153,8 +168,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.5.0...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.6.0...develop
 
+[1.6.0]: https://github.com/brainelectronics/micropython-modules/tree/1.6.0
 [1.5.0]: https://github.com/brainelectronics/micropython-modules/tree/1.5.0
 [1.4.0]: https://github.com/brainelectronics/micropython-modules/tree/1.4.0
 [1.3.0]: https://github.com/brainelectronics/micropython-modules/tree/1.3.0


### PR DESCRIPTION
### Added
- Use [changelog-based-release action](https://github.com/brainelectronics/changelog-based-release) to create a draft release with every merge to develop
- Use [changelog-based-release action](https://github.com/brainelectronics/changelog-based-release) to create a drafted prerelease release with every PR build

### Changed
- Apply changes for [micropython-modbus 2.0.0](https://github.com/brainelectronics/micropython-modbus/pull/33), see #16
- Scope of contents permissions in release and test release workflow is now `write` to use auto release creation
- Use `checkout@v3` instead of `checkout@v2` in all workflows
- Line breaks are no longer used in this changelog for enumerations
- Issues are referenced as `#123` instead of `[#123][ref-issue-123]` to avoid explicit references at the bottom or some other location in the file

### Fixed
- Use more specific `noqa` in [`led_helper.py`](be_helpers/led_helper.py)
