### PR TITLE
Make typing hints subscriptable

### DIFF
--- a/be_helpers/typing.py
+++ b/be_helpers/typing.py
@@ -10,6 +10,14 @@ https://github.com/micropython/micropython-lib/blob/3d779b8ceab5b65b9f70accbcbb1
 """
 
 
+class _Subscriptable():
+    def __getitem__(self, item):
+        return None
+
+
+_subscriptable = _Subscriptable()
+
+
 class Any:
     pass
 
@@ -22,12 +30,10 @@ class ClassVar:
     pass
 
 
-class Union:
-    pass
+Union = _subscriptable
 
 
-class Optional:
-    pass
+Optional = _subscriptable
 
 
 class Generic:
@@ -82,8 +88,7 @@ class Collection:
     pass
 
 
-class Callable:
-    pass
+Callable = _subscriptable
 
 
 class AbstractSet:
@@ -114,12 +119,10 @@ class ByteString:
     pass
 
 
-class Tuple:
-    pass
+Tuple = _subscriptable
 
 
-class List:
-    pass
+List = _subscriptable
 
 
 class Deque:
@@ -127,6 +130,10 @@ class Deque:
 
 
 class Set:
+    pass
+
+
+class dict_keys:
     pass
 
 
@@ -158,8 +165,7 @@ class AsyncContextManager:
     pass
 
 
-class Dict:
-    pass
+Dict = _subscriptable
 
 
 class DefaultDict:

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Released
+## [1.6.1] - 2023-01-29
+### Fixed
+- Typing hints for `Callable`, `Dict`, `List`, `Optional`, `Tuple` and `Union` are now subscriptable
+
 ## [1.6.0] - 2022-12-11
 ### Added
 - Use [changelog-based-release action](https://github.com/brainelectronics/changelog-based-release) to create a draft release with every merge to develop
@@ -168,8 +172,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`WifiHelper`](wifi_helper.py) module converted into class
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.6.0...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modules/compare/1.6.1...develop
 
+[1.6.1]: https://github.com/brainelectronics/micropython-modules/tree/1.6.1
 [1.6.0]: https://github.com/brainelectronics/micropython-modules/tree/1.6.0
 [1.5.0]: https://github.com/brainelectronics/micropython-modules/tree/1.5.0
 [1.4.0]: https://github.com/brainelectronics/micropython-modules/tree/1.4.0


### PR DESCRIPTION
### Fixed
- Typing hints for `Callable`, `Dict`, `List`, `Optional`, `Tuple` and `Union` are now subscriptable
